### PR TITLE
Adiciona información cuando se produce error de resultado sin descripción

### DIFF
--- a/src/main/java/op/congreso/pleno/CargaVotacionPlenos.java
+++ b/src/main/java/op/congreso/pleno/CargaVotacionPlenos.java
@@ -320,6 +320,7 @@ public class CargaVotacionPlenos implements Consumer<VotacionPlenos> {
         ps.setString(13, a.grupoParlamentarioDescripcion());
         ps.setString(14, a.resultado());
         if (a.resultadoDescripcion() == null) {
+          LOG.error("Error ubicado en: \n\tPleno: {}\n\tHora: {}\n\tCongresista: {}\n\tResultado no identificado: {} ", r.pleno().id(), r.hora(), a.congresista(), a.resultado());
           throw new IllegalArgumentException("a.resultadoDescripcion == null");
         }
         ps.setString(15, a.resultadoDescripcion());


### PR DESCRIPTION
En las votaciones cuando los códigos empleados no coinciden con las descripciones (Ej. se escribe los códigos con minúsculas) se produce un error de código sin descripción:
```
21:24:45.768 [op.congreso.pleno.CargaPlenos.main()] INFO op.congreso.pleno.CargaAsistenciaPlenos - Table asistencia_resultado updated
21:24:45.920 [op.congreso.pleno.CargaPlenos.main()] INFO op.congreso.pleno.CargaVotacionPlenos - Loading votacion_congresista
21:24:45.922 [op.congreso.pleno.CargaPlenos.main()] INFO op.congreso.pleno.CargaVotacionPlenos - Table votacion_congresista created
21:24:45.922 [op.congreso.pleno.CargaPlenos.main()] INFO op.congreso.pleno.CargaVotacionPlenos - Statement for votacion_congresista prepared
java.lang.IllegalArgumentException: a.resultadoDescripcion == null
        at op.congreso.pleno.CargaVotacionPlenos$VotacionCongresistaLoad.addBatch(CargaVotacionPlenos.java:323)
        at op.congreso.pleno.CargaVotacionPlenos.accept(CargaVotacionPlenos.java:50)
        at op.congreso.pleno.CargaPlenos.load(CargaPlenos.java:53)
        at op.congreso.pleno.CargaPlenos.main(CargaPlenos.java:28)
        at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:254)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

 Sin embargo, no se provee de mayor información para poder localizarlo. Por ello, se plantea agregar esta información en el error handle de tal manera que se pueda ubicar con mayor facilidad dentro de los excel.